### PR TITLE
fix: updates URL_REGEX to handle minified single css propery

### DIFF
--- a/tasks/css-url-embed.js
+++ b/tasks/css-url-embed.js
@@ -1,5 +1,5 @@
 module.exports = function(grunt) {
-  var URL_REGEX = /url\(["']?([^"'\(\)]+?)["']?\)[;, ](?!\s*?\/\*\s*?noembed\s*?\*\/)/;
+  var URL_REGEX = /url\(["']?([^"'\(\)]+?)["']?\)[};, ](?!\s*?\/\*\s*?noembed\s*?\*\/)/;
   var URL_FILTERING_REGEX = /^(data|http|https):/;
   
   var fs = require('fs');


### PR DESCRIPTION
Patch fixes this:

Works:
.a-background-image {background-image:url(/path/to/image.jpg);}
Don't work
.a-background-image {background-image:url(/path/to/image.jpg)}

Issue occured with https://github.com/GoalSmashers/clean-css
