### PR TITLE
Call callback even if there is nothing to embed

### DIFF
--- a/tasks/css-url-embed.js
+++ b/tasks/css-url-embed.js
@@ -159,6 +159,7 @@ module.exports = function(grunt) {
       
       if (embeddableUrls.length === 0) {
         grunt.log.writeln("Nothing to embed here!");
+        callback();
         return;
       }
       


### PR DESCRIPTION
"Nothing to embed" is a warning, not a fatal error, so callback should be called so the task completes and subsequent tasks run.
