### PR TITLE
Option to explicitly define which images get embedded

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Skip URLs that are larger than the specified value.
 
 For example: `'5 MB'`, `'30 KB'`, `'300 B'`.
 
+#### include
+Type: `Array` of image urls
+
+Default: null
+
+Excludes any images that are not explicitly defined in the include array.
+
 ### Excluding URLs manually
 
 You can mark certain URLs to be skipped by this task using the `/* noembed */` comment.

--- a/tasks/css-url-embed.js
+++ b/tasks/css-url-embed.js
@@ -155,7 +155,14 @@ module.exports = function(grunt) {
         allUrls.push(urlMatch[1]);
       }
       
-      var embeddableUrls = allUrls.filter(function(url) { return !url.match(URL_EXCLUDE_REGEX); });
+      var embeddableUrls = allUrls.filter(function(url) {
+        if(url.match(URL_EXCLUDE_REGEX))
+          return false;
+        if(options.include)
+          return (~options.include.indexOf(url));
+
+        return true;
+      });
       
       if (embeddableUrls.length === 0) {
         grunt.log.writeln("Nothing to embed here!");


### PR DESCRIPTION
I wanted to embed a few out of hundreds of images in my css without having to add /* noembed */ to every image reference. Usage example:
```
cssUrlEmbed: {
  encode: {
    options: { include: ['../img/Login-Icon.png', '../img/Home-Icon.png'] },
    files: { '/build/style.css': ['public/style.css'] }
}
```