### PR TITLE
Some cases fix

### DIFF
--- a/tasks/css-url-embed.js
+++ b/tasks/css-url-embed.js
@@ -61,7 +61,7 @@ module.exports = function(grunt) {
   }
   
   function processUrl(fileContent, currentUrlIndex, urlArray, options, baseDir, isVerbose, finishCallback) {
-    var url = urlArray[currentUrlIndex];
+    var url = urlArray[currentUrlIndex].replace(/#.+$/, '');
     var nextUrl = processNextUrl.bind(null, fileContent, currentUrlIndex, urlArray, options, baseDir, isVerbose, finishCallback);
     
     try {

--- a/tasks/css-url-embed.js
+++ b/tasks/css-url-embed.js
@@ -211,11 +211,13 @@ module.exports = function(grunt) {
     }
     
     existingFiles.forEach(function(file) {
-      processFile(file.src[0], file.dest, options, function() {
-        if (--leftToProcess === 0) {
-          async();
-        }
-      });
+      if (grunt.file.isFile(file.src[0])) {
+        processFile(file.src[0], file.dest, options, function() {
+          if (--leftToProcess === 0) {
+            async();
+          }
+        });
+      }
     });
   });
 };

--- a/tasks/css-url-embed.js
+++ b/tasks/css-url-embed.js
@@ -217,6 +217,8 @@ module.exports = function(grunt) {
             async();
           }
         });
+      } else {
+        async();
       }
     });
   });


### PR DESCRIPTION
This PR fixes:
- the source pattern could match directories (eg: installing `normalize.css` using bower creates `normalize.css` folder)
- local file url should trim the hash part of the original url (eg: some icomoon fonts have the hash `#icomoon` in the url)