### PR TITLE
Update request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "mime": "~1.3.0",
     "node-units": "~0.1.0",
-    "request": "~2.75.0"
+    "request": "~2.79.0"
   },
   "optionalDependencies": {
     "mmmagic": "~0.4.0"


### PR DESCRIPTION
Request 2.75.0 depends in node-uuid 1.4.7, which issues a deprecation warning. This should be fixed with request 2.79.0.