### PR TITLE
Allow spaces inside the url-notation parentheses

### DIFF
--- a/tasks/css-url-embed.js
+++ b/tasks/css-url-embed.js
@@ -1,5 +1,5 @@
 module.exports = function(grunt) {
-  var BASE_URL_REGEX = 'url\\(["\']?([^"\'\\(\\)]+?)["\']?\\)[};,!\\s]';
+  var BASE_URL_REGEX = 'url\\(\\s*["\']?([^"\'\\(\\)]+?)["\']?\\s*\\)[};,!\\s]';
   var EXCLUSIVE_URL_REGEX = BASE_URL_REGEX + '(?!\\s*?\\/\\*\\s*?noembed\\s*?\\*\\/)';
   var INCLUSIVE_URL_REGEX = BASE_URL_REGEX + '\\s*?\\/\\*\\s*?embed\\s*?\\*\\/';
   var EMBEDDABLE_URL_REGEX = /^data:/;


### PR DESCRIPTION
Without this, URLs like `url( 'foo.jpg' )` wouldn't be matched. URLs like `url( foo.jpg )` would match, but would then fail because the filename would be ` foo.jpg `.