### PR TITLE
New dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "mime": "~2.3.1",
     "node-units": "~0.1.0",
-    "request": "~2.79.0"
+    "request": "~2.88.0"
   },
   "optionalDependencies": {
     "mmmagic": "~0.4.0"

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
   "bugs": {
     "url": "https://github.com/mihhail-lapushkin/grunt-css-url-embed/issues"
   },
-  "licenses": [{
-    "type": "MIT",
-    "url": "https://github.com/mihhail-lapushkin/grunt-css-url-embed/blob/master/LICENSE-MIT"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/mihhail-lapushkin/grunt-css-url-embed/blob/master/LICENSE-MIT"
+    }
+  ],
   "engines": {
     "node": ">=0.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "mime": "~1.3.0",
+    "mime": "~2.3.1",
     "node-units": "~0.1.0",
     "request": "~2.79.0"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "request": "~2.88.0"
   },
   "optionalDependencies": {
-    "mmmagic": "~0.4.0"
+    "mmmagic": "~0.5.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
A few of this package's dependencies have outstanding vulnerabilities:

* `hoek` via `request` > `hawk` > `boom` and `request` > `hawk` > `cryptiles` > `boom` and `request` > `hawk` and `request` > `hawk` > `sntp` (!), fixed in `hoek` 5.0.3+
* `tunnel-agent` via `request`, fixed in `tunnel-agent` 0.6.0+
* `mime`, fixed in 2.0.3+

It'd be great to land this and release it to pull them to latest, if possible.